### PR TITLE
add new 1.19 deprecations

### DIFF
--- a/policies/1.19-deprek8ion.rego
+++ b/policies/1.19-deprek8ion.rego
@@ -14,6 +14,7 @@ warn[msg] {
 }
 
 # Based on https://github.com/kubernetes/kubernetes/blob/master/CHANGELOG/CHANGELOG-1.16.md
+# Based on https://github.com/kubernetes/kubernetes/blob/master/CHANGELOG/CHANGELOG-1.19.md
 
 # The admissionregistration.k8s.io/v1beta1 versions of MutatingWebhookConfiguration and ValidatingWebhookConfiguration are deprecated in 1.19. Migrate to use admissionregistration.k8s.io/v1 instead
 _warn = msg {
@@ -28,4 +29,40 @@ _warn = msg {
   input.apiVersion == "apiextensions.k8s.io/v1beta1"
   input.kind == "CustomResourceDefinition"
  msg := sprintf("%s/%s: API apiextensions.k8s.io/v1beta1 for CustomResourceDefinition is deprecated in 1.19, use apiextensions.k8s.io/v1 instead.", [input.kind, input.metadata.name])
+}
+
+# The apiregistration.k8s.io/v1beta1 version is deprecated in 1.19. Migrate to use apiregistration.k8s.io/v1 instead
+_warn = msg {
+  input.apiVersion == "apiregistration.k8s.io/v1beta1"
+  msg := sprintf("%s/%s: API apiregistration.k8s.io/v1beta1 is deprecated in Kubernetes 1.19, use apiregistration.k8s.io/v1 instead.", [input.kind, input.metadata.name])
+}
+
+# The authentication.k8s.io/v1beta1 version is deprecated in 1.19. Migrate to use authentication.k8s.io/v1 instead
+_warn = msg {
+  input.apiVersion == "authentication.k8s.io/v1beta1"
+  msg := sprintf("%s/%s: API authentication.k8s.io/v1beta1 is deprecated in Kubernetes 1.19, use authentication.k8s.io/v1 instead.", [input.kind, input.metadata.name])
+}
+
+# The authorization.k8s.io/v1beta1 version is deprecated in 1.19. Migrate to use authorization.k8s.io/v1 instead
+_warn = msg {
+  input.apiVersion == "authorization.k8s.io/v1beta1"
+  msg := sprintf("%s/%s: API authorization.k8s.io/v1beta1 is deprecated in Kubernetes 1.19, use authorization.k8s.io/v1 instead.", [input.kind, input.metadata.name])
+}
+
+# The autoscaling/v2beta1 version is deprecated in 1.19. Migrate to use autoscaling/v2beta2 instead
+_warn = msg {
+  input.apiVersion == "autoscaling/v2beta1"
+  msg := sprintf("%s/%s: API autoscaling/v2beta1 is deprecated in Kubernetes 1.19, use autoscaling/v2beta2 instead.", [input.kind, input.metadata.name])
+}
+
+# The coordination.k8s.io/v1beta1 version is deprecated in 1.19. Migrate to use coordination.k8s.io/v1 instead
+_warn = msg {
+  input.apiVersion == "coordination.k8s.io/v1beta1"
+  msg := sprintf("%s/%s: API coordination.k8s.io/v1beta1 is deprecated in Kubernetes 1.19, use coordination.k8s.io/v1 instead.", [input.kind, input.metadata.name])
+}
+
+# The storage.k8s.io/v1beta1 version is deprecated in 1.19. Migrate to use storage.k8s.io/v1 instead
+_warn = msg {
+  input.apiVersion == "storage.k8s.io/v1beta1"
+  msg := sprintf("%s/%s: API storage.k8s.io/v1beta1 is deprecated in Kubernetes 1.19, use storage.k8s.io/v1 instead.", [input.kind, input.metadata.name])
 }


### PR DESCRIPTION
Add new deprecations in 1.19 (mostly removed in 1.22)
https://github.com/kubernetes/kubernetes/blob/master/CHANGELOG/CHANGELOG-1.19.md

I added these new deprecations to the 1.19 file. I saw, that some deprecations were present there (e.g. admissionregistration.k8s.io/v1beta1). But those are deprecated since 1.16 and not since 1.19 (which is said in the warn-message) and are no longer served from 1.19. Maybe they should be moved to the 1.16 file? I didn't check other files yet...

For context of this question: I wrote a tool (https://github.com/code-chris/k8spolicy) a few weeks ago to automate the validation based on this policies and there's a setting to ignore warnings for a range of k8s-versions (if they are not yet relevant) and this is done via the filename of the policy-file...