### PR TITLE
simplified Dockerfile by basing it on the conftest image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,14 +1,7 @@
-FROM alpine:3
+FROM instrumenta/conftest:v0.18.2
+
 LABEL MAINTAINER Steven Wade <steven@stevenwade.co.uk>
 
-# Install necessary tooling
-RUN apk add --no-cache curl bash execline findutils && rm -rf /var/cache/apk/*
-
-# Copy in rego policies to work with Conftest.
 COPY policies/* /policies/
 
-COPY install.sh /install.sh
-RUN chmod +x /install.sh
-RUN /install.sh
-
-CMD ["/bin/sh"]
+ENTRYPOINT ["/conftest", "test", "-p", "/policies"]

--- a/README.md
+++ b/README.md
@@ -5,22 +5,24 @@
 
 A set of rego policies to monitor Kubernetes APIs deprecations.
 
-The Kubernetes API deprecations can be found using https://relnotes.k8s.io/?markdown=deprecated.
+The Kubernetes API deprecations can be found using <https://relnotes.k8s.io/?markdown=deprecated>.
 
 ## Docker image
+
 The docker container contains the most recent version of [conftest](https://github.com/instrumenta/conftest) as well as the policies at `/policies`.
 
-Image tags can be found at https://quay.io/repository/swade1987/deprek8ion?tab=tags. 
+Image tags can be found at <https://quay.io/repository/swade1987/deprek8ion?tab=tags>.
 
 ## Example usage
 
 An example of how to use the docker container can be seen below:
 
-```
-docker run --rm --name demo -v $(pwd)/demo:/demo quay.io/swade1987/deprek8ion:1.1.7 conftest test -p /policies /demo/ingress.yaml
+```sh
+docker run --rm --name demo -v $(pwd)/demo:/demo quay.io/swade1987/deprek8ion:1.1.7 /demo/ingress.yaml
 ```
 
 Or directly pipe some resources into the container:
-```
-cat /demo/ingress.yaml | docker run --rm -i quay.io/swade1987/deprek8ion:1.1.7 conftest test -p /policies -
+
+```sh
+cat ./demo/ingress.yaml | docker run --rm -i quay.io/swade1987/deprek8ion:1.1.7 -
 ```

--- a/install.sh
+++ b/install.sh
@@ -1,9 +1,0 @@
-#!/usr/bin/env bash
-
-set -uo errexit
-
-CONFTEST=0.18.0
-printf "\ndownloading conftest ${CONFTEST}\n"
-curl -sSL https://github.com/instrumenta/conftest/releases/download/v${CONFTEST}/conftest_${CONFTEST}_Linux_x86_64.tar.gz | \
-tar xz && mv conftest /usr/local/bin/conftest
-conftest --version


### PR DESCRIPTION
This slightly simplifies the Dockerfile by basing it on the conftest base image.

In it's current form, it's a breaking change as I've modified the container's ENTRYPOINT: running `docker run --rm --name demo -v $(pwd)/demo:/demo quay.io/swade1987/deprek8ion:1.1.7 conftest test -p /policies /demo/ingress.yaml` from the README will no longer work, as the entire `conftest test -p /policies` part has been moved inside the ENTRYPOINT.

Let me know if you'd prefer to keep backwards-compatibility and use the previous ENTRYPOINT instead.