### PR TITLE
Update artifacthub-pkg.yml file

### DIFF
--- a/policies/artifacthub-pkg.yml
+++ b/policies/artifacthub-pkg.yml
@@ -5,7 +5,9 @@ createdAt: 2020-07-27T18:00:00Z
 description: A set of rego policies to monitor Kubernetes APIs deprecations
 license: MIT
 homeURL: https://github.com/swade1987/deprek8ion
-containerImage: eu.gcr.io/swade1987/deprek8ion:1.1.17
+containersImages:
+  - name: deprek8ion
+    image: eu.gcr.io/swade1987/deprek8ion:1.1.17
 keywords:
   - monitoring
   - kubernetes


### PR DESCRIPTION
`containerImage` has been replaced by `containersImages`, which allows for multiple entries and some extra information, like a name for the image.

https://github.com/artifacthub/hub/blob/d2919c736bef1e59cc5ac9a4f0e54eb9d4d275cf/docs/metadata/artifacthub-pkg.yml#L12-L14

Signed-off-by: Sergio Castaño Arteaga <tegioz@icloud.com>