### PR TITLE
extensions/v1beta1 Ingress is deprecated in 1.19, not 1.20

### DIFF
--- a/policies/kubernetes-1.19.rego
+++ b/policies/kubernetes-1.19.rego
@@ -58,9 +58,9 @@ _warn = msg {
   msg := sprintf("%s/%s: API storage.k8s.io/v1beta1 is deprecated in Kubernetes 1.19, use storage.k8s.io/v1 instead.", [input.kind, input.metadata.name])
 }
 
-# Ingress resources will no longer be served from extensions/v1beta1 in v1.19. Migrate use to the networking.k8s.io/v1beta1 API, available since v1.14.
+# Ingress resources will no longer be served from extensions/v1beta1 in v1.19. Migrate use to the networking.k8s.io/v1 API, available since v1.14.
 _warn = msg {
   input.apiVersion == "extensions/v1beta1"
   input.kind == "Ingress"
-  msg := sprintf("%s/%s: API extensions/v1beta1 for Ingress is deprecated from Kubernetes 1.19, use networking.k8s.io/v1beta1 instead.", [input.kind, input.metadata.name])
+  msg := sprintf("%s/%s: API extensions/v1beta1 for Ingress is deprecated from Kubernetes 1.19, use networking.k8s.io/v1 instead.", [input.kind, input.metadata.name])
 }

--- a/policies/kubernetes-1.19.rego
+++ b/policies/kubernetes-1.19.rego
@@ -13,7 +13,6 @@ warn[msg] {
   msg := _warn
 }
 
-# Based on https://github.com/kubernetes/kubernetes/blob/master/CHANGELOG/CHANGELOG-1.16.md
 # Based on https://github.com/kubernetes/kubernetes/blob/master/CHANGELOG/CHANGELOG-1.19.md
 
 # The apiextensions.k8s.io/v1beta1 version of CustomResourceDefinition is deprecated in 1.19. Migrate to use apiextensions.k8s.io/v1 instead
@@ -57,4 +56,11 @@ _warn = msg {
 _warn = msg {
   input.apiVersion == "storage.k8s.io/v1beta1"
   msg := sprintf("%s/%s: API storage.k8s.io/v1beta1 is deprecated in Kubernetes 1.19, use storage.k8s.io/v1 instead.", [input.kind, input.metadata.name])
+}
+
+# Ingress resources will no longer be served from extensions/v1beta1 in v1.19. Migrate use to the networking.k8s.io/v1beta1 API, available since v1.14.
+_warn = msg {
+  input.apiVersion == "extensions/v1beta1"
+  input.kind == "Ingress"
+  msg := sprintf("%s/%s: API extensions/v1beta1 for Ingress is deprecated from Kubernetes 1.19, use networking.k8s.io/v1beta1 instead.", [input.kind, input.metadata.name])
 }

--- a/policies/kubernetes-1.20.rego
+++ b/policies/kubernetes-1.20.rego
@@ -15,23 +15,9 @@ warn[msg] {
 
 # Based on https://github.com/kubernetes/kubernetes/blob/master/CHANGELOG/CHANGELOG-1.16.md
 
-# Ingress resources will no longer be served from extensions/v1beta1 in v1.20. Migrate use to the networking.k8s.io/v1beta1 API, available since v1.14.
-_warn = msg {
-  input.apiVersion == "extensions/v1beta1"
-  input.kind == "Ingress"
-  msg := sprintf("%s/%s: API extensions/v1beta1 for Ingress is deprecated from Kubernetes 1.20, use networking.k8s.io/v1beta1 instead.", [input.kind, input.metadata.name])
-}
-
 # All resources will no longer be served from rbac.authorization.k8s.io/v1alpha1 and rbac.authorization.k8s.io/v1beta1 in 1.20. Migrate to use rbac.authorization.k8s.io/v1 instead
 _warn = msg {
   apis := ["rbac.authorization.k8s.io/v1alpha1", "rbac.authorization.k8s.io/v1beta1"]
   input.apiVersion == apis[_]
   msg := sprintf("%s/%s: API %s is deprecated from Kubernetes 1.20, use rbac.authorization.k8s.io/v1 instead.", [input.kind, input.metadata.name, input.apiVersion])
-}
-
-# Ingress resources will no longer be served from extensions/v1beta1 in v1.20. Migrate use to the networking.k8s.io/v1beta1 API, available since v1.14.
-_warn = msg {
-  input.apiVersion == "extensions/v1beta1"
-  input.kind == "Ingress"
-  msg := sprintf("%s/%s: API extensions/v1beta1 for Ingress is deprecated from Kubernetes 1.20, use networking.k8s.io/v1beta1 instead.", [input.kind, input.metadata.name])
 }


### PR DESCRIPTION
Based on the behaviour of kubectl 1.19