### PR TITLE
Add networking.k8s.io/v1beta1 ingress policy

### DIFF
--- a/policies/kubernetes-1.19.rego
+++ b/policies/kubernetes-1.19.rego
@@ -64,3 +64,10 @@ _warn = msg {
   input.kind == "Ingress"
   msg := sprintf("%s/%s: API extensions/v1beta1 for Ingress is deprecated from Kubernetes 1.19, use networking.k8s.io/v1 instead.", [input.kind, input.metadata.name])
 }
+
+# Ingress resources will no longer be served from networking.k8s.io/v1beta1 in v1.19. Migrate use to the networking.k8s.io/v1 API, available since v1.14.
+_warn = msg {
+  input.apiVersion == "networking.k8s.io/v1beta1"
+  input.kind == "Ingress"
+  msg := sprintf("%s/%s: API networking.k8s.io/v1beta1 for Ingress is deprecated from Kubernetes 1.19, use networking.k8s.io/v1 instead.", [input.kind, input.metadata.name])
+}


### PR DESCRIPTION
In addition to `extensions/v1beta1`, `networking.k8s.io/v1beta1` was
also deprecated in 1.19 and is also targeted for removal in 1.22.

Deprecation PR: https://github.com/kubernetes/kubernetes/pull/89778
Removal mention in deprecation guide: https://kubernetes.io/docs/reference/using-api/deprecation-guide/#ingress-v122
